### PR TITLE
Add workflow to publish this plugin to LuaRocks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: "release"
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v4
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          detailed_description: |
+            A high-performance color highlighter for Neovim which has no external dependencies!
+            Written in performant Luajit.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A high-performance color highlighter for Neovim which has **no external dependen
 
 ## Installation and Usage
 
+[![LuaRocks](https://img.shields.io/luarocks/v/norcalli/nvim-colorizer.lua?logo=lua&color=purple)](https://luarocks.org/modules/norcalli/nvim-colorizer.lua)
+
 Requires Neovim >= 0.4.0 and `set termguicolors` (I'm looking into relaxing
 these constraints). If you don't have true color for your terminal or are
 unsure, [read this excellent guide](https://github.com/termstandard/colors).


### PR DESCRIPTION
### Summary

This PR is part of a push to get Neovim plugins on LuaRocks.

* See [this blog post](https://mrcjkb.github.io/posts/2023-01-10-luarocks-tag-release.html), which follows up on [a series of posts](https://teto.github.io/posts/2021-09-17-neovim-plugin-luarocks.html) by @teto.

### Things done:

* Add a workflow that publishes tags to LuaRocks when a tag is pushed.
* Add a LuaRocks badge to the readme (assuming the existence of a `norcalli/nvim-colorizer.lua` package).

### Notes

* For the release workflow to work, someone with a Luarocks account will have to add their [API key](https://luarocks.org/settings/api-keys) to this repo's [GitHub actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
* Due to a shortcoming in LuaRocks (https://github.com/luarocks/luarocks-site/issues/188), the `neovim` label has to be added  to the LuaRocks package manually (after the first upload), for this plugin to show up in https://luarocks.org/labels/neovim
* If you would prefer rolling releases without tags, [this is also possible](https://github.com/nvim-neorocks/luarocks-tag-release#version-optional).

__Adding the API key (screen shot)__
![github-add-luarocks-api-key](https://user-images.githubusercontent.com/12857160/211071297-afb129be-7a8f-4662-b282-9d52bb0286de.png)