### PR TITLE
refactor: replace deprecated vim.tbl_flatten with vim.iter(...):flatten():totable()

### DIFF
--- a/lua/colorizer/nvim.lua
+++ b/lua/colorizer/nvim.lua
@@ -93,7 +93,8 @@ return setmetatable({
 			end
 			local command = k:gsub("_$", "!")
 			local f = function(...)
-				return vim.api.nvim_command(table.concat(vim.tbl_flatten {command, ...}, " "))
+				local args = vim.iter({command, ...}):flatten():totable()
+				return vim.api.nvim_command(table.concat(args, " "))
 			end
 			mt[k] = f
 			return f


### PR DESCRIPTION
Replaced usage of deprecated `vim.tbl_flatten` with the new recommended pattern
`vim.iter(...):flatten():totable()` to ensure compatibility with Neovim 0.13+.

This change prevents deprecation warnings and ensures forward compatibility as
`vim.tbl_flatten` is scheduled for removal in a future release.