### PR TITLE
Fix: Replace deprecated functions without breaking backward compatibility

### DIFF
--- a/lua/colorizer/nvim.lua
+++ b/lua/colorizer/nvim.lua
@@ -1,25 +1,28 @@
 --- Module of magic functions for nvim
 -- @module nvim
 
+-- Import version independent wrapper functions of deprecated api functions
+local utils = require("colorizer.utils")
+
 -- Equivalent to `echo vim.inspect(...)`
 local function nvim_print(...)
 	if select("#", ...) == 1 then
-		vim.api.nvim_out_write(vim.inspect((...)))
+		utils.out_write(vim.inspect((...)))
 	else
-		vim.api.nvim_out_write(vim.inspect {...})
+		utils.out_write(vim.inspect {...})
 	end
-	vim.api.nvim_out_write("\n")
+	utils.out_write("\n")
 end
 
 --- Equivalent to `echo` EX command
 local function nvim_echo(...)
 	for i = 1, select("#", ...) do
 		local part = select(i, ...)
-		vim.api.nvim_out_write(tostring(part))
+		utils.out_write(tostring(part))
 		-- vim.api.nvim_out_write("\n")
-		vim.api.nvim_out_write(" ")
+		utils.out_write(" ")
 	end
-	vim.api.nvim_out_write("\n")
+	utils.out_write("\n")
 end
 
 local window_options = {

--- a/lua/colorizer/nvim.lua
+++ b/lua/colorizer/nvim.lua
@@ -96,7 +96,7 @@ return setmetatable({
 			end
 			local command = k:gsub("_$", "!")
 			local f = function(...)
-				return vim.api.nvim_command(table.concat(vim.tbl_flatten {command, ...}, " "))
+				return vim.api.nvim_command(table.concat(utils.flatten_table({command, ...}), " "))
 			end
 			mt[k] = f
 			return f

--- a/lua/colorizer/nvim.lua
+++ b/lua/colorizer/nvim.lua
@@ -52,7 +52,7 @@ local window_options = {
 -- TODO `nvim.ex.$command(...)` is approximately `:$command {...}.join(" ")`
 -- `nvim.print(...)` is approximately `echo vim.inspect(...)`
 -- `nvim.echo(...)` is approximately `echo table.concat({...}, '\n')`
--- Both methods cache the inital lookup in the metatable, but there is a small overhead regardless.
+-- Both methods cache the initial lookup in the metatable, but there is a small overhead regardless.
 return setmetatable({
 	print = nvim_print;
 	echo = nvim_echo;
@@ -148,28 +148,28 @@ return setmetatable({
 	});
 	o = setmetatable({}, {
 		__index = function(_, k)
-			return vim.api.nvim_get_option(k)
+			return utils.get_option(k)
 		end;
 		__newindex = function(_, k, v)
-			return vim.api.nvim_set_option(k, v)
+			return utils.set_option(k, v)
 		end
 	});
 	-- TODO add warning if you try to use a window option here?
 	bo = setmetatable({}, {
 		__index = function(_, k)
-			return vim.api.nvim_buf_get_option(0, k)
+			return utils.buf_get_option(0, k)
 		end;
 		__newindex = function(_, k, v)
-			return vim.api.nvim_buf_set_option(0, k, v)
+			return utils.buf_set_option(0, k, v)
 		end
 	});
 	wo = setmetatable({}, {
 		__index = function(_, k)
-			return vim.api.nvim_win_get_option(0, k)
+			return utils.win_get_option(0, k)
 		end;
 		__newindex = function(_, k, v)
 			-- passing v == nil will clear the value, just like above.
-			return vim.api.nvim_win_set_option(0, k, v)
+			return utils.win_set_option(0, k, v)
 		end
 	});
 	env = setmetatable({}, {

--- a/lua/colorizer/utils.lua
+++ b/lua/colorizer/utils.lua
@@ -1,0 +1,73 @@
+return {
+	out_write = function(str)
+		if vim.fn.has("nvim-0.11") == 1 then
+			vim.api.nvim_echo({ { str } }, true, {})
+		else
+			---@diagnostic disable-next-line: deprecated
+			vim.api.nvim_out_write(str)
+		end
+	end,
+
+	flatten_table = function(table)
+		if vim.fn.has("nvim-0.11") == 1 then
+			return vim.iter(table):flatten():totable()
+		else
+			---@diagnostic disable-next-line: deprecated
+			return vim.tbl_flatten(table)
+		end
+	end,
+
+	get_option = function(option)
+		if vim.fn.has("nvim-0.10") == 1 then
+			return vim.api.nvim_get_option_value(option, {})
+		else
+			---@diagnostic disable-next-line: deprecated
+			return vim.api.nvim_get_option(option)
+		end
+	end,
+
+	set_option = function(option, value)
+		if vim.fn.has("nvim-0.10") == 1 then
+			return vim.api.nvim_set_option_value(option, value, {})
+		else
+			---@diagnostic disable-next-line: deprecated
+			return vim.api.nvim_set_option(option, value)
+		end
+	end,
+
+	buf_get_option = function(buf_nr, option)
+		if vim.fn.has("nvim-0.10") == 1 then
+			return vim.api.nvim_get_option_value(option, { buf = buf_nr })
+		else
+			---@diagnostic disable-next-line: deprecated
+			return vim.api.nvim_buf_get_option(buf_nr, option)
+		end
+	end,
+
+	buf_set_option = function(buf_nr, option, value)
+		if vim.fn.has("nvim-0.10") == 1 then
+			return vim.api.nvim_set_option_value(option, value, { buf = buf_nr })
+		else
+			---@diagnostic disable-next-line: deprecated
+			return vim.api.nvim_buf_set_option(buf_nr, option, value)
+		end
+	end,
+
+	win_get_option = function(win_nr, option)
+		if vim.fn.has("nvim-0.10") == 1 then
+			return vim.api.nvim_get_option_value(option, { win = win_nr })
+		else
+			---@diagnostic disable-next-line: deprecated
+			return vim.api.nvim_win_get_option(win_nr, option)
+		end
+	end,
+
+	win_set_option = function(win_nr, option, value)
+		if vim.fn.has("nvim-0.10") == 1 then
+			return vim.api.nvim_set_option_value(option, value, { win = win_nr })
+		else
+			---@diagnostic disable-next-line: deprecated
+			return vim.api.nvim_win_set_option(win_nr, option, value)
+		end
+	end,
+}


### PR DESCRIPTION
### Description

Replaces deprecated functions with utility functions that either call the new or the old api functions depending on the users Neovim version.

### Replaced functions:

- `nvim_out_write` for nvim version >= 0.11
- `tbl_flatten` for nvim version >= 0.11
- `nvim_get_option` for nvim version >= 0.10
- `nvim_set_option` for nvim version >= 0.10
- `nvim_buf_get_option` for nvim version >= 0.10
- `nvim_buf_set_option` for nvim version >= 0.10
- `nvim_win_get_option` for nvim version >= 0.10
- `nvim_win_set_option` for nvim version >= 0.10